### PR TITLE
Add multi-symbol worker and simple frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bot Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    .buy { color: green; }
+    .sell { color: red; }
+  </style>
+</head>
+<body>
+  <h1>Signals</h1>
+  <div id="signals"></div>
+  <h1>Trades</h1>
+  <div id="trades"></div>
+  <script>
+    async function refresh() {
+      try {
+        const [sRes, tRes] = await Promise.all([
+          fetch('/signals'),
+          fetch('/trades')
+        ]);
+        const signals = await sRes.json();
+        const trades = await tRes.json();
+        const sDiv = document.getElementById('signals');
+        sDiv.innerHTML = '';
+        signals.forEach(sig => {
+          const div = document.createElement('div');
+          div.textContent = `${sig.symbol}: ${sig.signal} @ ${sig.price}`;
+          div.className = sig.signal === 'BUY' ? 'buy' : 'sell';
+          sDiv.appendChild(div);
+        });
+        const tDiv = document.getElementById('trades');
+        tDiv.innerHTML = '';
+        trades.forEach(tr => {
+          const div = document.createElement('div');
+          div.textContent = `${tr.symbol}: ${tr.side} @ ${tr.price}`;
+          div.className = tr.side === 'BUY' ? 'buy' : 'sell';
+          tDiv.appendChild(div);
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    refresh();
+    setInterval(refresh, 3000);
+  </script>
+</body>
+</html>

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,65 @@
+import time
+from typing import Any, Dict, List
+
+import requests
+
+BASE_URL = "http://localhost:8000"
+SYMBOLS: List[str] = [
+    "BTC/USDT:USDT",
+    "XRP/USDT:USDT",
+    "DOGE/USDT:USDT",
+    "TRUMP/USDT:USDT",
+]
+
+
+def fetch_analysis(symbol: str) -> Dict[str, Any] | None:
+    """Fetch market analysis for a symbol.
+
+    Returns None if the request fails.
+    """
+    try:
+        resp = requests.get(f"{BASE_URL}/analysis", params={"symbol": symbol}, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        print(f"analysis error for {symbol}: {exc}")
+        return None
+
+
+def post(path: str, data: Dict[str, Any]) -> None:
+    """Send a JSON POST request and ignore failures."""
+    try:
+        requests.post(f"{BASE_URL}{path}", json=data, timeout=10)
+    except Exception as exc:  # pragma: no cover - network errors
+        print(f"post {path} failed: {exc}")
+
+
+def process_symbol(symbol: str) -> None:
+    analysis = fetch_analysis(symbol)
+    if not analysis:
+        return
+
+    signal = (
+        analysis.get("signal")
+        or analysis.get("summary", {}).get("RECOMMENDATION")
+        or analysis.get("recommendation")
+    )
+    price = analysis.get("price") or analysis.get("last_price") or analysis.get("close")
+
+    if signal in {"BUY", "SELL"} and price is not None:
+        post("/signals", {"symbol": symbol, "signal": signal, "price": price})
+        post(
+            "/trade",
+            {"symbol": symbol, "side": signal, "price": price, "mode": "paper"},
+        )
+
+
+def main() -> None:
+    while True:
+        for symbol in SYMBOLS:
+            process_symbol(symbol)
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add worker script looping through multiple symbols and posting signals/trades in paper mode
- Create lightweight frontend to view signals and trades with auto-refresh

## Testing
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*
- `python -m py_compile worker.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7de24176c8326a249b151e6ac7cf8